### PR TITLE
Upgrading esbuild to support s390x architercture

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/hypercore-skunkworks/wasm-tools#readme",
   "dependencies": {
     "commander": "^8.3.0",
-    "esbuild": "^0.13.8",
+    "esbuild": "^0.14.51",
     "wabt": "^1.0.24"
   },
   "devDependencies": {


### PR DESCRIPTION
npm install fails on s390x system architecture due to outdated esbuild. This PR upgrades esbuild to its latest version and with that way the npm install works properly on s390x systems.